### PR TITLE
Add Support for Reinforced Shulker Boxes

### DIFF
--- a/src/main/java/de/onebacon/drops_into_shulker/ShulkerInventoryWrapper.java
+++ b/src/main/java/de/onebacon/drops_into_shulker/ShulkerInventoryWrapper.java
@@ -2,17 +2,19 @@ package de.onebacon.drops_into_shulker;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.BlockWithEntity;
 import net.minecraft.block.entity.ShulkerBoxBlockEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.util.DyeColor;
+import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.util.math.BlockPos;
+
 import org.jetbrains.annotations.Nullable;
 
-import static de.onebacon.drops_into_shulker.DropsIntoShulker.LOGGER;
-
 /**
- * Wrapper of ShulkerBoxBlockEntity, to allow writing of NBT and adding stacks, similar to SimpleInventory.
+ * Wrapper of ShulkerBoxBlockEntity, to allow writing of NBT and adding stacks,
+ * similar to SimpleInventory.
  */
 public class ShulkerInventoryWrapper extends ShulkerBoxBlockEntity {
     @SuppressWarnings("unused")
@@ -22,6 +24,12 @@ public class ShulkerInventoryWrapper extends ShulkerBoxBlockEntity {
 
     public ShulkerInventoryWrapper(ItemStack item, NbtCompound nbt) {
         super(BlockPos.ORIGIN, Block.getBlockFromItem(item.getItem()).getDefaultState());
+
+        // properly get the shulkerbox size and prime the entity inventory
+        var correctEntity = (ShulkerSizeExt) ((BlockWithEntity) Block.getBlockFromItem(item.getItem()))
+                .createBlockEntity(BlockPos.ORIGIN, getCachedState());
+        setInvStackList(DefaultedList.ofSize(correctEntity.getInvSize(), ItemStack.EMPTY));
+
         readNbt(nbt);
     }
 
@@ -33,9 +41,8 @@ public class ShulkerInventoryWrapper extends ShulkerBoxBlockEntity {
 
     public ItemStack addStack(ItemStack stack) {
         ItemStack itemStack = stack.copy();
-        //Prevent shulker stacking
-        if (!this.canInsert(0, stack, null))
-        {
+        // Prevent shulker stacking
+        if (!this.canInsert(0, stack, null)) {
             return itemStack;
         }
 
@@ -46,7 +53,7 @@ public class ShulkerInventoryWrapper extends ShulkerBoxBlockEntity {
     }
 
     private void addToExistingSlot(ItemStack stack) {
-        for (int i = 0; i < INVENTORY_SIZE; ++i) {
+        for (int i = 0; i < this.size(); ++i) {
             ItemStack itemStack = this.getStack(i);
             if (ItemStack.canCombine(itemStack, stack)) {
                 this.transfer(stack, itemStack);
@@ -59,7 +66,7 @@ public class ShulkerInventoryWrapper extends ShulkerBoxBlockEntity {
     }
 
     private void addToNewSlot(ItemStack stack) {
-        for (int i = 0; i < INVENTORY_SIZE; ++i) {
+        for (int i = 0; i < this.size(); ++i) {
             ItemStack itemStack = this.getStack(i);
             if (itemStack.isEmpty()) {
                 this.setStack(i, stack.copy());
@@ -76,9 +83,8 @@ public class ShulkerInventoryWrapper extends ShulkerBoxBlockEntity {
         if (j > 0) {
             target.increment(j);
             source.decrement(j);
-            //this.markDirty();
+            // this.markDirty();
         }
     }
-
 
 }

--- a/src/main/java/de/onebacon/drops_into_shulker/ShulkerSizeExt.java
+++ b/src/main/java/de/onebacon/drops_into_shulker/ShulkerSizeExt.java
@@ -1,0 +1,5 @@
+package de.onebacon.drops_into_shulker;
+
+public interface ShulkerSizeExt {
+  public int getInvSize();
+}

--- a/src/main/java/de/onebacon/drops_into_shulker/mixin/ShulkerBoxBlockEntityMixin.java
+++ b/src/main/java/de/onebacon/drops_into_shulker/mixin/ShulkerBoxBlockEntityMixin.java
@@ -1,0 +1,19 @@
+package de.onebacon.drops_into_shulker.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import de.onebacon.drops_into_shulker.ShulkerSizeExt;
+import net.minecraft.block.entity.ShulkerBoxBlockEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.collection.DefaultedList;
+
+@Mixin(ShulkerBoxBlockEntity.class)
+public class ShulkerBoxBlockEntityMixin implements ShulkerSizeExt {
+  @Shadow
+  private DefaultedList<ItemStack> inventory;
+
+  public int getInvSize() {
+    return inventory.size();
+  }
+}

--- a/src/main/resources/drops-into-shulker.mixins.json
+++ b/src/main/resources/drops-into-shulker.mixins.json
@@ -4,10 +4,10 @@
   "package": "de.onebacon.drops_into_shulker.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "PlayerInventoryMixin"
+    "PlayerInventoryMixin",
+    "ShulkerBoxBlockEntityMixin"
   ],
-  "client": [
-  ],
+  "client": [],
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
I've been playing with the [Reinforced Shulker Boxes Mod](https://modrinth.com/mod/reinforced-shulker-boxes) and found that this mod would wipe out any item data after the 27th slot due to the temporary block entity having the default number of slots.

An overview of the changes:
- add a mixin for ShulkerBoxBlockEntity that allows getting the size of the private inventory field
- use that size when creating the `ShulkerInventoryWrapper` before reading offhand NBT data